### PR TITLE
Show build status of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A library for building asynchronous user interfaces.
 
-[![travis-ci](https://travis-ci.org/yolkjs/yolk.svg)](https://travis-ci.org/yolkjs/yolk)
+[![travis-ci](https://travis-ci.org/yolkjs/yolk.svg?branch=master)](https://travis-ci.org/yolkjs/yolk)
 
 * __Familiar__: Yolk is a small library built on top of [Virtual DOM](https://github.com/Matt-Esch/virtual-dom) and [RxJS](https://github.com/Reactive-Extensions/RxJS). It exposes a very limited API so that you don't have to spend weeks getting up to speed. Yolk components are just plain functions that return JSX.
 


### PR DESCRIPTION
Hey!

Thanks for making this, and for making it available.

I just noticed when I read about the project that the travis build status icon was red and failing, which came from the fact that the README links to the latest build, which might at a given time be a WIP branch with failing tests.

So, right now it is green again, but at least here is a very minor PR to make sure it always displays the master build status. Who knows, someone might loose confidence in a project based on a red build status :)

Thanks again, have a nice week!