### PR TITLE
WIP: Remove Element creation from Base and Composite components

### DIFF
--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -34,10 +34,9 @@ YolkBaseComponent.prototype = {
     const innerComponent = new YolkBaseInnerComponent(this.id)
     const node = innerComponent.createNode()
 
-    this._patchSubscription =
-      Rx.Observable
-        .combineLatest(propObservable, childObservable)
-        .subscribe(([props, children]) => innerComponent.update(props, children))
+    this._disposable =
+      propObservable.combineLatest(childObservable)
+      .subscribe(([props, children]) => innerComponent.update(props, children))
 
     mountable.emitMount(node, this._props.onMount)
 
@@ -47,7 +46,7 @@ YolkBaseComponent.prototype = {
   update (previous) {
     this._propSubject = previous._propSubject
     this._childSubject = previous._childSubject
-    this._patchSubscription = previous._patchSubscription
+    this._disposable = previous._disposable
 
     this._propSubject.onNext(this._props)
     this._childSubject.onNext(this._children)
@@ -58,7 +57,7 @@ YolkBaseComponent.prototype = {
   },
 
   destroy () {
-    this._patchSubscription.dispose()
+    this._disposable.dispose()
 
     const children = this._children
     const length = children.length

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -36,7 +36,10 @@ YolkBaseComponent.prototype = {
 
     this._disposable =
       propObservable.combineLatest(childObservable)
-      .subscribe(([props, children]) => innerComponent.update(props, children))
+      .subscribe(
+        ([props, children]) => innerComponent.update(props, children),
+        (err) => {throw err}
+      )
 
     mountable.emitMount(node, this._props.onMount)
 

--- a/src/YolkBaseInnerComponent.js
+++ b/src/YolkBaseInnerComponent.js
@@ -1,0 +1,37 @@
+const h = require(`yolk-virtual-dom/h`)
+const create = require(`yolk-virtual-dom/create-element`)
+const diff = require(`yolk-virtual-dom/diff`)
+const patch = require(`yolk-virtual-dom/patch`)
+const generateUid = require(`./generateUid`)
+
+function YolkBaseInnerComponent (tag) {
+  this._tag = tag
+  this._props = {}
+  this._children = []
+  this._uid = generateUid()
+  this._vNode = null
+  this._node = null
+}
+
+YolkBaseInnerComponent.prototype = {
+  createNode () {
+    this._vNode = h(this._tag, this._props, this._children)
+    this._node = create(this._vNode)
+    return this._node
+  },
+
+  update (props, children) {
+    this._props = props
+    this._children = children
+
+    if (this._node) {
+      const vNode = h(this._tag, props, children)
+      const patches = diff(this._vNode, vNode)
+
+      this._vNode = vNode
+      patch(this._node, patches)
+    }
+  },
+}
+
+module.exports = YolkBaseInnerComponent

--- a/src/generateUid.js
+++ b/src/generateUid.js
@@ -1,0 +1,3 @@
+module.exports = function generateUid () {
+  return (Math.random() * 0x100000000000000).toString(36)
+}

--- a/test/unit/YolkBaseComponent-test.js
+++ b/test/unit/YolkBaseComponent-test.js
@@ -50,7 +50,7 @@ test(`YolkBaseComponent: listens for mount and umount when defined`, t => {
   node.addEventListener(`unmount`, handler)
 
   setTimeout(() => {
-    instance.predestroy()
+    instance.predestroy(node)
     node.removeEventListener(`mount`, handler)
     node.removeEventListener(`unmount`, handler)
     cleanup()


### PR DESCRIPTION
If we don't ever call `virtualDom#create` from the Base and Composite components then server rendering becomes possible.

- [x] Abstract away updating the node into `YolkBaseInnerComponent`. Leave `YolkBaseComponent` for wrangling and updating props/children subscriptions.
- [ ] Update `yolk-virtual-dom` to include a `postinit` hook so that I can move the `mount` event to it.
- [ ] Update Root component to properly create a node. (or update create in `yolk-vritual-dom` to do it properly)

Questions:
- Can probably just take this pattern and apply it directly to CustomComponent?

Notes:
- Remember to re-include the error catching for subscriptions

Long story short, `init` in both Base and Composite should return a virtual node.