### PR TITLE
Add load event

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Yolk supports the following list of standard browser events,
 onAbort onBlur onCanPlay onCanPlayThrough onChange onClick onContextMenu onCopy
 onCueChange onCut onDblClick onDrag onDragEnd onDragEnter onDragLeave onDragOver
 onDragStart onDrop onDurationChange onEmptied onEnded onError onFocus onInput
-onInvalid onKeyDown onKeyPress onKeyUp onLoadedData onLoadedMetaData onLoadStart
+onInvalid onKeyDown onKeyPress onKeyUp onLoad onLoadedData onLoadedMetaData onLoadStart
 onMouseDown onMouseMove onMouseOut onMouseOver onMouseUp onPaste onPause onPlay
 onPlaying onProgress onRateChange onReset onScroll onSearch onSeeked onSeeking
 onSelect onShow onStalled onSubmit onSuspend onTimeUpdate onToggle onVolumeChange

--- a/src/EventsList.js
+++ b/src/EventsList.js
@@ -27,6 +27,7 @@ module.exports = [
   `KeyDown`,
   `KeyPress`,
   `KeyUp`,
+  `Load`,
   `LoadedData`,
   `LoadedMetaData`,
   `LoadStart`,


### PR DESCRIPTION
> The `load` event is fired when a resource and its dependent resources have finished loading

See: https://developer.mozilla.org/en-US/docs/Web/Events/load

Example

```js
export default function Image(props) {
  const {
    src
    } = props;

  function onLoad() {
    console.log('image loaded');
  }

  return (
    <figure role='img'>
      <img role='presentation'
           src={src}
           onLoad={onLoad}/>
    </figure>
  );
}
```